### PR TITLE
Hardcode allauth to use https on prod

### DIFF
--- a/kerckhoff/kerckhoff/settings.py
+++ b/kerckhoff/kerckhoff/settings.py
@@ -35,7 +35,6 @@ DEBUG = env('DEBUG')
 
 if not DEBUG:
     ALLOWED_HOSTS = [ env('SITE_HOST'), ]
-    ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
 else:
     ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]', env('SITE_HOST')]
 
@@ -173,6 +172,10 @@ ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_AUTHENTICATION_METHOD = 'email'
 ACCOUNT_USERNAME_REQUIRED = True
 SITE_ID = 1
+
+if not DEBUG:
+    # Set https as default on production
+    ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
 
 SOCIALACCOUNT_PROVIDERS = {
     'google': {

--- a/kerckhoff/kerckhoff/settings.py
+++ b/kerckhoff/kerckhoff/settings.py
@@ -35,6 +35,7 @@ DEBUG = env('DEBUG')
 
 if not DEBUG:
     ALLOWED_HOSTS = [ env('SITE_HOST'), ]
+    ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
 else:
     ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]', env('SITE_HOST')]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ configparser==3.5.0
 coreapi==2.3.3
 coreschema==0.0.4
 defusedxml==0.5.0
-django-allauth==0.38.0
+django-allauth==0.43.0
 django-cors-headers==2.2.0
 django-environ==0.4.4
 django-extensions==1.8.1


### PR DESCRIPTION
Recently, allauth has been having an issue where it was redirecting to http instead of https. This PR will force it to use https by default when the DEBUG environment variable is False.